### PR TITLE
Improve listeners performances

### DIFF
--- a/src/main/java/de/epiceric/shopchest/listeners/HologramUpdateListener.java
+++ b/src/main/java/de/epiceric/shopchest/listeners/HologramUpdateListener.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 
@@ -18,7 +19,7 @@ public class HologramUpdateListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlayerMove(PlayerMoveEvent e) {
 
         if (e.getFrom().getBlockX() == e.getTo().getBlockX()

--- a/src/main/java/de/epiceric/shopchest/listeners/HologramUpdateListener.java
+++ b/src/main/java/de/epiceric/shopchest/listeners/HologramUpdateListener.java
@@ -20,8 +20,17 @@ public class HologramUpdateListener implements Listener {
 
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent e) {
+
+        if (e.getFrom().getBlockX() == e.getTo().getBlockX()
+                && e.getFrom().getBlockZ() == e.getTo().getBlockZ()
+                && e.getFrom().getBlockY() == e.getTo().getBlockY()) {
+            return;
+        }
+
         Player p = e.getPlayer();
         Location playerLocation = p.getLocation();
+        double hologramDistanceSquared = plugin.getShopChestConfig().maximal_distance;
+        hologramDistanceSquared *= hologramDistanceSquared;
 
         for (Shop shop : plugin.getShopUtils().getShops()) {
             Block b = shop.getLocation().getBlock();
@@ -36,7 +45,7 @@ public class HologramUpdateListener implements Listener {
             Location shopLocation = shop.getLocation();
 
             if (playerLocation.getWorld().equals(shopLocation.getWorld())) {
-                if (playerLocation.distance(shop.getHologram().getLocation()) <= plugin.getShopChestConfig().maximal_distance) {
+                if (playerLocation.distanceSquared(shop.getHologram().getLocation()) <= hologramDistanceSquared) {
                     if (!shop.getHologram().isVisible(p)) {
                         shop.getHologram().showPlayer(p);
                     }

--- a/src/main/java/de/epiceric/shopchest/listeners/ShopItemListener.java
+++ b/src/main/java/de/epiceric/shopchest/listeners/ShopItemListener.java
@@ -4,7 +4,9 @@ import de.epiceric.shopchest.ShopChest;
 import de.epiceric.shopchest.shop.Shop;
 import de.epiceric.shopchest.utils.ShopUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -25,38 +27,26 @@ public class ShopItemListener implements Listener {
         this.shopUtils = plugin.getShopUtils();
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlayerMove(PlayerMoveEvent e) {
-        Player p = e.getPlayer();
-        for (Shop shop : shopUtils.getShops()) {
-            if (shop.getLocation().distance(p.getLocation()) <= plugin.getShopChestConfig().maximal_item_distance) {
-                shop.getItem().setVisible(p, true);
-            } else {
-                shop.getItem().setVisible(p, false);
-            }
+
+        if (e.getFrom().getBlockX() == e.getTo().getBlockX()
+                && e.getFrom().getBlockZ() == e.getTo().getBlockZ()
+                && e.getFrom().getBlockY() == e.getTo().getBlockY()) {
+            return;
         }
+
+        updateShopVisibility(e.getPlayer(), true);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlayerTeleport(PlayerTeleportEvent e) {
-        Player p = e.getPlayer();
-        for (Shop shop : shopUtils.getShops()) {
-            if (shop.getLocation().distance(e.getTo()) <= plugin.getShopChestConfig().maximal_item_distance) {
-                shop.getItem().setVisible(p, true);
-            } else {
-                shop.getItem().setVisible(p, false);
-            }
-        }
+        updateShopVisibility(e.getPlayer(), true, e.getTo());
     }
 
     @EventHandler
-    public void onPlayerJoin(final PlayerJoinEvent e) {
-        Player p = e.getPlayer();
-        for (Shop shop : shopUtils.getShops()) {
-            if (shop.getLocation().distance(p.getLocation()) <= plugin.getShopChestConfig().maximal_item_distance) {
-                shop.getItem().setVisible(p, true);
-            }
-        }
+    public void onPlayerJoin(PlayerJoinEvent e) {
+        updateShopVisibility(e.getPlayer(), false);
     }
 
     @EventHandler
@@ -64,6 +54,27 @@ public class ShopItemListener implements Listener {
         for (Shop shop : plugin.getShopUtils().getShops()) {
             shop.getItem().setVisible(e.getPlayer(), false);
         }
+    }
+
+    private void updateShopVisibility(Player p, boolean hideIfAway) {
+        updateShopVisibility(p, hideIfAway, p.getLocation());
+    }
+
+    private void updateShopVisibility(Player p, boolean hideIfAway, Location playerLocation) {
+
+        double itemDistanceSquared = plugin.getShopChestConfig().maximal_item_distance;
+        itemDistanceSquared *= itemDistanceSquared;
+        World w = p.getWorld();
+
+        for (Shop shop : shopUtils.getShops()) {
+            Location shopLocation = shop.getLocation();
+            if (w.equals(shopLocation.getWorld()) && shopLocation.distanceSquared(playerLocation) <= itemDistanceSquared) {
+                shop.getItem().setVisible(p, true);
+            } else if (hideIfAway) {
+                shop.getItem().setVisible(p, false);
+            }
+        }
+
     }
 
     @EventHandler(priority = EventPriority.HIGH)

--- a/src/main/java/de/epiceric/shopchest/listeners/ShopItemListener.java
+++ b/src/main/java/de/epiceric/shopchest/listeners/ShopItemListener.java
@@ -36,17 +36,17 @@ public class ShopItemListener implements Listener {
             return;
         }
 
-        updateShopVisibility(e.getPlayer(), true);
+        updateShopItemVisibility(e.getPlayer(), true);
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlayerTeleport(PlayerTeleportEvent e) {
-        updateShopVisibility(e.getPlayer(), true, e.getTo());
+        updateShopItemVisibility(e.getPlayer(), true, e.getTo());
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent e) {
-        updateShopVisibility(e.getPlayer(), false);
+        updateShopItemVisibility(e.getPlayer(), false);
     }
 
     @EventHandler
@@ -56,11 +56,11 @@ public class ShopItemListener implements Listener {
         }
     }
 
-    private void updateShopVisibility(Player p, boolean hideIfAway) {
-        updateShopVisibility(p, hideIfAway, p.getLocation());
+    private void updateShopItemVisibility(Player p, boolean hideIfAway) {
+        updateShopItemVisibility(p, hideIfAway, p.getLocation());
     }
 
-    private void updateShopVisibility(Player p, boolean hideIfAway, Location playerLocation) {
+    private void updateShopItemVisibility(Player p, boolean hideIfAway, Location playerLocation) {
 
         double itemDistanceSquared = plugin.getShopChestConfig().maximal_item_distance;
         itemDistanceSquared *= itemDistanceSquared;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -55,7 +55,7 @@ append-potion-level-to-item-name: false
 remove-shop-on-error: false
 
 # Set the maximal distance (in blocks) to the shop where the player can see the hologram.
-maximal-distance: 1.75
+maximal-distance: 2
 
 # Set the maximal distance (in blocks) to the shop where the player can see the floatig shop item.
 maximal-item-distance: 40


### PR DESCRIPTION
This should slightly improve performances, especially with a lot of shops.
Now shops are updated only on block changes and not every move event.
It also uses distanceSquared instead of distance to avoid sqrt operations.