### PR TITLE
world.equals(world) consumes 63% of the method cpu time, replaced wit…

### DIFF
--- a/src/main/java/de/epiceric/shopchest/listeners/HologramUpdateListener.java
+++ b/src/main/java/de/epiceric/shopchest/listeners/HologramUpdateListener.java
@@ -52,8 +52,8 @@ public class HologramUpdateListener implements Listener {
             if (shop.getHologram() == null) continue;
 
             Location shopLocation = shop.getLocation();
-
-            if (playerLocation.getWorld().equals(shopLocation.getWorld())) {
+            
+            if (playerLocation.getWorld().getName().equals(shopLocation.getWorld().getName())) {
                 if (playerLocation.distanceSquared(shop.getHologram().getLocation()) <= hologramDistanceSquared) {
                     if (!shop.getHologram().isVisible(p)) {
                         shop.getHologram().showPlayer(p);


### PR DESCRIPTION
…h world.getName().equals(world.getName())

Explanation:
When using .equals() on classes with many variables and methods, means that every single thing on the class would be checked to be equals to the one from the another class, and its taking too much cpu.

hope that you can accept this commit.