### PR TITLE
Add multi-world plugins in softdepend

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ version: ${project.version}
 author: EpicEric
 website: ${project.url}
 description: Create your own nice-looking chest shops and sell your stuff to other players!
-softdepend: [WorldGuard, Towny, AuthMe, PlotSquared, uSkyBlock, ASkyBlock, IslandWorld, GriefPrevention, AreaShop]
+softdepend: [WorldGuard, Towny, AuthMe, PlotSquared, uSkyBlock, ASkyBlock, IslandWorld, GriefPrevention, AreaShop, Multiverse-Core, MultiWorld]
 depend: [Vault]
 
 permissions:


### PR DESCRIPTION
I had an issue where ShopChest will reload during startup, that created duplicate holograms. Doing this seems to have resolved the issue, as ShopChest will more likely load after worlds are loaded.