### PR TITLE
Performance improvements & shop updater refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,21 +6,30 @@
 
     <groupId>de.epiceric</groupId>
     <artifactId>ShopChest</artifactId>
-    <packaging>jar</packaging>
     <version>${version.final}</version>
-    <name>ShopChest</name>
+
+    <name>${project.artifactId}</name>
     <url>https://www.spigotmc.org/resources/shopchest.11431/</url>
     <description>Let your players create their own nice-looking shops to sell their stuff to other players!</description>
+    <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <!-- Project Properties -->
+        <projectEncoding>UTF-8</projectEncoding>
+        <project.build.sourceEncoding>${projectEncoding}</project.build.sourceEncoding>
+        <project.build.outputEncoding>${projectEncoding}</project.build.outputEncoding>
 
+        <!-- JDK Version -->
+        <jdkVersion>1.7</jdkVersion>
+        <maven.compiler.source>${jdkVersion}</maven.compiler.source>
+        <maven.compiler.target>${jdkVersion}</maven.compiler.target>
+
+        <!-- Versioning -->
         <version.number>1.12.3</version.number>
         <version.final>${version.number}-${version.git}</version.final>
 
+        <!-- Others -->
         <github.global.server>github</github.global.server>
-
         <javadoc.opts><!-- Only jdk 1.8 and later --></javadoc.opts>
     </properties>
 
@@ -252,6 +261,7 @@
                             <shadedPattern>de.epiceric.shopchest.utils</shadedPattern>
                         </relocation>
                     </relocations>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/de/epiceric/shopchest/ShopChest.java
+++ b/src/main/java/de/epiceric/shopchest/ShopChest.java
@@ -185,7 +185,7 @@ public class ShopChest extends JavaPlugin {
 
         if (updater != null) {
             debug("Stopping updater");
-            updater.cancel();
+            updater.stop();
         }
 
         if (database != null) {
@@ -431,13 +431,6 @@ public class ShopChest extends JavaPlugin {
      */
     public ShopUpdater getUpdater() {
         return updater;
-    }
-
-    /**
-     * Set the {@link ShopUpdater} that schedules hologram and item updates
-     */
-    public void setUpdater(ShopUpdater updater) {
-        this.updater = updater;
     }
 
     /**

--- a/src/main/java/de/epiceric/shopchest/listeners/ShopItemListener.java
+++ b/src/main/java/de/epiceric/shopchest/listeners/ShopItemListener.java
@@ -4,9 +4,7 @@ import de.epiceric.shopchest.ShopChest;
 import de.epiceric.shopchest.shop.Shop;
 import de.epiceric.shopchest.utils.ShopUtils;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -15,7 +13,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.*;
-import org.bukkit.event.player.*;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.world.StructureGrowEvent;
 
 public class ShopItemListener implements Listener {
@@ -33,6 +32,9 @@ public class ShopItemListener implements Listener {
         for (Shop shop : plugin.getShopUtils().getShops()) {
             if (shop.getItem() != null) {
                 shop.getItem().setVisible(e.getPlayer(), false);
+            }
+            if (shop.getHologram() != null) {
+                shop.getHologram().hidePlayer(e.getPlayer());
             }
         }
     }

--- a/src/main/java/de/epiceric/shopchest/listeners/ShopUpdateListener.java
+++ b/src/main/java/de/epiceric/shopchest/listeners/ShopUpdateListener.java
@@ -1,19 +1,10 @@
 package de.epiceric.shopchest.listeners;
 
 import de.epiceric.shopchest.ShopChest;
-import de.epiceric.shopchest.shop.Shop;
 import de.epiceric.shopchest.utils.Callback;
-import de.epiceric.shopchest.utils.ShopUpdater;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerChangedWorldEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.world.WorldLoadEvent;
-import org.bukkit.scheduler.BukkitRunnable;
 
 public class ShopUpdateListener implements Listener {
 
@@ -21,48 +12,6 @@ public class ShopUpdateListener implements Listener {
 
     public ShopUpdateListener(ShopChest plugin) {
         this.plugin = plugin;
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onPlayerTeleport(final PlayerTeleportEvent e) {
-        // Wait till the chunk should have loaded on the client
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                hideShops(e.getPlayer(), true);
-                plugin.getShopUtils().updateShops(e.getPlayer(), true);
-            }
-        }.runTaskLater(plugin, 15L);
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR)
-    public void onPlayerJoin(PlayerJoinEvent e) {
-        restartShopUpdater(e.getPlayer());
-    }
-
-    // The Bukkit::getOnlinePlayers() list does not include players that
-    // are currently respawning or chaning worlds, so when only one player is
-    // online and is currently respawning, the updater will think that no player
-    // is online, so it will stop. To prevent that, a delay of 1 tick is needed.
-
-    @EventHandler
-    public void onPlayerChangedWorld(final PlayerChangedWorldEvent e) {
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                restartShopUpdater(e.getPlayer());
-            }
-        }.runTaskLater(plugin, 1L);
-    }
-
-    @EventHandler
-    public void onPlayerRespawn(final PlayerRespawnEvent e) {
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                restartShopUpdater(e.getPlayer());
-            }
-        }.runTaskLater(plugin, 1L);
     }
 
     @EventHandler
@@ -81,24 +30,4 @@ public class ShopUpdateListener implements Listener {
             }
         });
     }
-
-    private void restartShopUpdater(Player p) {
-        if (!plugin.getUpdater().isRunning()) {
-            plugin.setUpdater(new ShopUpdater(plugin));
-            plugin.getUpdater().start();
-        }
-
-        hideShops(p, false);
-    }
-
-    private void hideShops(Player p, boolean onlyItem) {
-        for (Shop shop : plugin.getShopUtils().getShops()) {
-            if (!onlyItem) {
-                if (shop.getHologram() != null) shop.getHologram().hidePlayer(p);
-            }
-
-            if (shop.getItem() != null) shop.getItem().setVisible(p, false);
-        }
-    }
-
 }

--- a/src/main/java/de/epiceric/shopchest/listeners/ShopUpdateListener.java
+++ b/src/main/java/de/epiceric/shopchest/listeners/ShopUpdateListener.java
@@ -1,10 +1,16 @@
 package de.epiceric.shopchest.listeners;
 
 import de.epiceric.shopchest.ShopChest;
+import de.epiceric.shopchest.shop.Shop;
 import de.epiceric.shopchest.utils.Callback;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.world.WorldLoadEvent;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class ShopUpdateListener implements Listener {
 
@@ -12,6 +18,41 @@ public class ShopUpdateListener implements Listener {
 
     public ShopUpdateListener(ShopChest plugin) {
         this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerTeleport(PlayerTeleportEvent e) {
+        Location from = e.getFrom();
+        Location to = e.getTo();
+        final Player p = e.getPlayer();
+
+        // Wait till the chunk should have loaded on the client
+        // Update IF worlds are different OR chunks are different (as many teleports are in same chunk)
+        if (!from.getWorld().equals(to.getWorld())
+                || from.getChunk().getX() != to.getChunk().getX()
+                || from.getChunk().getZ() != to.getChunk().getZ()) {
+            // Wait for 15 ticks before we actually put it in the queue
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    plugin.getUpdater().beforeNext(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (p.isOnline()) {
+                                for (Shop shop : plugin.getShopUtils().getShops()) {
+                                    if (shop.getItem() != null) {
+                                        shop.getItem().setVisible(p, false);
+                                    }
+                                    if (shop.getHologram() != null) {
+                                        shop.getHologram().hidePlayer(p);
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
+            }.runTaskLater(plugin, 15L);
+        }
     }
 
     @EventHandler

--- a/src/main/java/de/epiceric/shopchest/nms/Hologram.java
+++ b/src/main/java/de/epiceric/shopchest/nms/Hologram.java
@@ -10,18 +10,20 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Hologram {
 
     private static List<Hologram> holograms = new ArrayList<>();
 
+    private final Set<UUID> visibility = Collections.newSetFromMap(new ConcurrentHashMap<UUID, Boolean>());
+    private final List<ArmorStandWrapper> wrappers = new ArrayList<>();
+    private final Location location;
+    private final ShopChest plugin;
+    private final Config config;
+
     private boolean exists = false;
-    private List<ArmorStandWrapper> wrappers = new ArrayList<>();
     private ArmorStandWrapper interactArmorStandWrapper;
-    private Location location;
-    private Set<UUID> visibility = new HashSet<>();
-    private ShopChest plugin;
-    private Config config;
 
     public Hologram(ShopChest plugin, String[] lines, Location location) {
         this.plugin = plugin;
@@ -254,7 +256,9 @@ public class Hologram {
      */
     public static Hologram getHologram(ArmorStand armorStand) {
         for (Hologram hologram : holograms) {
-            if (hologram.contains(armorStand)) return hologram;
+            if (hologram.contains(armorStand)) {
+                return hologram;
+            }
         }
 
         return null;
@@ -265,12 +269,7 @@ public class Hologram {
      * @return Whether the armor stand is part of a hologram
      */
     public static boolean isPartOfHologram(ArmorStand armorStand) {
-        for (Hologram hologram : holograms) {
-            if (hologram.contains(armorStand)) {
-                return true;
-            }
-        }
-        return false;
+        return getHologram(armorStand) != null;
     }
 
 }

--- a/src/main/java/de/epiceric/shopchest/shop/ShopItem.java
+++ b/src/main/java/de/epiceric/shopchest/shop/ShopItem.java
@@ -2,6 +2,7 @@ package de.epiceric.shopchest.shop;
 
 import de.epiceric.shopchest.ShopChest;
 import de.epiceric.shopchest.utils.Utils;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -9,13 +10,14 @@ import org.bukkit.inventory.ItemStack;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 
 public class ShopItem {
 
     private ShopChest plugin;
-    private Map<Player, Boolean> visible = new HashMap<>();
+    private Set<UUID> visibility = new HashSet<>();
     private ItemStack itemStack;
     private Location location;
 
@@ -88,8 +90,9 @@ public class ShopItem {
     }
 
     public void remove() {
-        for (Player p : visible.keySet()) {
-            if (isVisible(p)) setVisible(p, false);
+        for (UUID uuid : visibility) {
+            Player p = Bukkit.getPlayer(uuid);
+            if (p != null) setVisible(p, false);
         }
     }
 
@@ -103,7 +106,7 @@ public class ShopItem {
     }
 
     public boolean isVisible(Player p) {
-        return visible.get(p) == null ? false : visible.get(p);
+        return visibility.contains(p.getUniqueId());
     }
 
     public void setVisible(final Player p, boolean visible) {
@@ -114,6 +117,7 @@ public class ShopItem {
             for (Object packet : this.creationPackets) {
                 Utils.sendPacket(plugin, packet, p);
             }
+            visibility.add(p.getUniqueId());
         } else {
             try {
                 if (p.isOnline()) {
@@ -125,9 +129,8 @@ public class ShopItem {
                 plugin.debug("Failed to destroy shop item with reflection");
                 plugin.debug(e);
             }
+            visibility.remove(p.getUniqueId());
         }
-
-        this.visible.put(p, visible);
     }
 
 

--- a/src/main/java/de/epiceric/shopchest/shop/ShopItem.java
+++ b/src/main/java/de/epiceric/shopchest/shop/ShopItem.java
@@ -10,16 +10,17 @@ import org.bukkit.inventory.ItemStack;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ShopItem {
 
-    private ShopChest plugin;
-    private Set<UUID> visibility = new HashSet<>();
-    private ItemStack itemStack;
-    private Location location;
+    private final ShopChest plugin;
+    private final Set<UUID> visibility = Collections.newSetFromMap(new ConcurrentHashMap<UUID, Boolean>());
+    private final ItemStack itemStack;
+    private final Location location;
 
     private Object entityItem;
     private int entityId;

--- a/src/main/java/de/epiceric/shopchest/utils/ShopUtils.java
+++ b/src/main/java/de/epiceric/shopchest/utils/ShopUtils.java
@@ -18,6 +18,7 @@ import java.util.*;
 public class ShopUtils {
 
     private final HashMap<Location, Shop> shopLocation = new HashMap<>();
+    private final Collection<Shop> shopLocationValues = Collections.unmodifiableCollection(shopLocation.values());
     private final HashMap<UUID, Location> playerLocation = new HashMap<>();
     private final ShopChest plugin;
 
@@ -48,11 +49,11 @@ public class ShopUtils {
     }
 
     /**
-     * Get all Shops
-     * @return Array of all Shops
+     * Get all shops
+     * @return Read-only collection of all shops, may contain duplicates
      */
-    public Shop[] getShops() {
-        return shopLocation.values().toArray(new Shop[0]);
+    public Collection<Shop> getShops() {
+        return shopLocationValues;
     }
 
     /**

--- a/src/main/java/de/epiceric/shopchest/utils/ShopUtils.java
+++ b/src/main/java/de/epiceric/shopchest/utils/ShopUtils.java
@@ -13,16 +13,13 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.util.Vector;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class ShopUtils {
 
-    private HashMap<Location, Shop> shopLocation = new HashMap<>();
-    private HashMap<Player, Location> playerLocation = new HashMap<>();
-    private ShopChest plugin;
+    private final HashMap<Location, Shop> shopLocation = new HashMap<>();
+    private final HashMap<UUID, Location> playerLocation = new HashMap<>();
+    private final ShopChest plugin;
 
     public ShopUtils(ShopChest plugin) {
         this.plugin = plugin;
@@ -55,8 +52,7 @@ public class ShopUtils {
      * @return Array of all Shops
      */
     public Shop[] getShops() {
-        Collection<Shop> shops = shopLocation.values();
-        return shops.toArray(new Shop[shops.size()]);
+        return shopLocation.values().toArray(new Shop[0]);
     }
 
     /**
@@ -274,7 +270,7 @@ public class ShopUtils {
      * @param force Whether update should be forced even if player has not moved
      */
     public void updateShops(Player player, boolean force) {
-        if (!force && player.getLocation().equals(playerLocation.get(player))) {
+        if (!force && player.getLocation().equals(playerLocation.get(player.getUniqueId()))) {
             // Player has not moved, so don't calculate shops again.
             return;
         }
@@ -314,7 +310,7 @@ public class ShopUtils {
             updateNearestShops(player);
         }
 
-        playerLocation.put(player, player.getLocation());
+        playerLocation.put(player.getUniqueId(), player.getLocation());
     }
 
     private Set<Shop> getShopsInSight(Player player) {

--- a/src/main/java/de/epiceric/shopchest/utils/ShopUtils.java
+++ b/src/main/java/de/epiceric/shopchest/utils/ShopUtils.java
@@ -218,10 +218,7 @@ public class ShopUtils {
         if (reloadConfig) {
             plugin.getShopChestConfig().reload(false, true, showConsoleMessages);
             plugin.getHologramFormat().reload();
-            plugin.getUpdater().cancel();
-
-            plugin.setUpdater(new ShopUpdater(plugin));
-            plugin.getUpdater().start();
+            plugin.getUpdater().restart();
         }
 
         plugin.getShopDatabase().connect(new Callback(plugin) {
@@ -314,9 +311,7 @@ public class ShopUtils {
                 }
             }
         } else {
-            for (Shop shop : getShops()) {
-                updateShop(shop, player);
-            }
+            updateNearestShops(player);
         }
 
         playerLocation.put(player, player.getLocation());
@@ -370,27 +365,36 @@ public class ShopUtils {
         double holoDistSqr = Math.pow(plugin.getShopChestConfig().maximal_distance, 2);
         double itemDistSqr = Math.pow(plugin.getShopChestConfig().maximal_item_distance, 2);
 
+        updateShop(shop, player, holoDistSqr, itemDistSqr);
+    }
+
+    private void updateNearestShops(Player p) {
+        double holoDistSqr = Math.pow(plugin.getShopChestConfig().maximal_distance, 2);
+        double itemDistSqr = Math.pow(plugin.getShopChestConfig().maximal_item_distance, 2);
+
+        for (Shop shop : getShops()) {
+            updateShop(shop, p, holoDistSqr, itemDistSqr);
+        }
+    }
+
+    private void updateShop(Shop shop, Player player, double holoDistSqr, double itemDistSqr) {
         if (player.getLocation().getWorld().getName().equals(shop.getLocation().getWorld().getName())) {
             double distSqr = shop.getLocation().distanceSquared(player.getLocation());
 
-            if (distSqr <= holoDistSqr) {
-                if (shop.getHologram() != null) {
-                    if (!shop.getHologram().isVisible(player)) {
-                        shop.getHologram().showPlayer(player);
-                    }
-                }
-            } else {
-                if (shop.getHologram() != null) {
+            if (shop.getHologram() != null) {
+                if (distSqr <= holoDistSqr) {
+                    shop.getHologram().showPlayer(player);
+                } else {
                     shop.getHologram().hidePlayer(player);
                 }
             }
 
-            if (distSqr <= itemDistSqr) {
-                if (shop.getItem() != null) {
+            if (shop.getItem() != null) {
+                if (distSqr <= itemDistSqr) {
                     shop.getItem().setVisible(player, true);
+                } else {
+                    shop.getItem().setVisible(player, false);
                 }
-            } else {
-                if (shop.getItem() != null) shop.getItem().setVisible(player, false);
             }
         }
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ version: ${project.version}
 author: EpicEric
 website: ${project.url}
 description: Create your own nice-looking chest shops and sell your stuff to other players!
-softdepend: [WorldGuard, Towny, AuthMe, PlotSquared, uSkyBlock, ASkyBlock, IslandWorld, GriefPrevention, AreaShop]
+softdepend: [WorldGuard, Towny, AuthMe, PlotSquared, uSkyBlock, ASkyBlock, IslandWorld, GriefPrevention, AreaShop, Multiverse-Core, MultiWorld]
 depend: [Vault]
 
 permissions:


### PR DESCRIPTION
Changes:
- Fix issue #130 
- Merge PR #129 
- `ShopUpdater` is created once, then it manages its inner task, `ShopUpdaterTask`
- ShopUpdaterTask is always running, even if there is no player online
_Listening for 3 events (respawn, change world, login) to start/stop task is more intensive than running the task no matter what_
- Created method `updateNearestShops`, so square of `maximal_distance` and `maximal_item_distance` is calculated only once

Ask me if something needs to be changed, or if you have question about what I've done.