### PR TITLE
Add Nashorn Engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,11 @@
             <artifactId>reflectionhelper</artifactId>
             <version>1.18.4-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/de/epiceric/shopchest/config/HologramFormat.java
+++ b/src/main/java/de/epiceric/shopchest/config/HologramFormat.java
@@ -7,7 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
+import javax.script.ScriptEngineFactory;
 import javax.script.ScriptException;
 
 import org.bukkit.configuration.ConfigurationSection;
@@ -15,6 +15,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 import de.epiceric.shopchest.ShopChest;
 import de.epiceric.shopchest.utils.Operator;
+import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
 
 public class HologramFormat {
 
@@ -31,8 +32,8 @@ public class HologramFormat {
     // e.g.: "STONE" == "DIAMOND_SWORD"
     private static final Pattern SIMPLE_STRING_CONDITION = Pattern.compile("^\"([^\"]*)\" ([=!]=) \"([^\"]*)\"$");
 
-    private ScriptEngineManager manager = new ScriptEngineManager();
-    private ScriptEngine engine = manager.getEngineByName("JavaScript");
+    private ScriptEngineFactory factory = new NashornScriptEngineFactory();
+    private ScriptEngine engine = factory.getScriptEngine();
 
     private ShopChest plugin;
     private File configFile;


### PR DESCRIPTION
Fix #371 

Nashorn Engine were removed in Java 15 and Minecraft 1.17 required Java 16.
So we have to add Nashorn Engine manually.